### PR TITLE
Potential fix for code scanning alert no. 43: Type confusion through parameter tampering

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -19,6 +19,10 @@ class ErrorWithParent extends Error {
 module.exports = function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
     let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    if (typeof criteria !== 'string') {
+      res.status(400).send('Bad request')
+      return
+    }
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
Potential fix for [https://github.com/im-infomagnus/juice-shop/security/code-scanning/43](https://github.com/im-infomagnus/juice-shop/security/code-scanning/43)

To fix this vulnerability, we must ensure `criteria` is of type string before any string methods are used. The recommended fix is to add a type check immediately after extracting `req.query.q`: if the value is not a string, handle this as an error (e.g., return HTTP 400 Bad Request). You should add a check: `if (typeof criteria !== 'string') { res.status(400).send('Bad request'); return; }` right after line 21, before using string methods like `.length` and `.substring`. This ensures that only strings are processed and prevents type confusion attacks where an array could bypass validations or be misinterpreted.

The only required code changes are in file `routes/search.ts`, immediately after line 21.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
